### PR TITLE
Fix inference state dict prefix stripping

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -383,12 +383,12 @@ def run_inference(args: argparse.Namespace) -> Tuple[np.ndarray, np.ndarray]:
         state_dict = checkpoint.get("state_dict")
     if state_dict is None:
         state_dict = checkpoint
-    def _strip_prefix(sd: dict, prefix: str):
+    def _strip_prefix(sd: Any, prefix: str):
         if not isinstance(sd, dict) or not sd:
             return sd
         keys = list(sd.keys())
         if all(k.startswith(prefix) for k in keys):
-            return {k[len(prefix):]: v for k, v in sd.items()}
+            return type(sd)((k[len(prefix):], v) for k, v in sd.items())
         return sd
 
     # Handle wrappers such as torch.compile that prepend "_orig_mod." or DDP's "module.".


### PR DESCRIPTION
## Summary
- preserve the original mapping type when removing prefixes from checkpoint state dicts during inference

## Testing
- python -m compileall inference.py

------
https://chatgpt.com/codex/tasks/task_e_68d82d3ba304832a9c097e73bdcb4760