### PR TITLE
Fix DataLoader worker init for spawn context

### DIFF
--- a/ddp.py
+++ b/ddp.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 import os, re, glob, math, time, random, gc, contextlib, argparse, io, hashlib
+from functools import partial
 from dataclasses import dataclass, field
 from typing import List, Dict, Tuple, Optional, Iterable, Any
 from datetime import datetime, timedelta
@@ -37,6 +38,7 @@ import torch.nn.functional as F
 from torch.utils.data import Dataset, DataLoader
 from torch.utils.data.distributed import DistributedSampler
 import torch.distributed as dist
+import torch.multiprocessing as mp
 from torch.optim.lr_scheduler import LinearLR, SequentialLR
 from tqdm.auto import tqdm
 
@@ -1929,6 +1931,13 @@ def build_sources(rank=0):
         print("⚠️  Could not infer radar ordering from folder names; using provided order.", flush=True)
     return sources
 
+def _seed_worker(worker_id: int, base_seed: int, rank: int) -> None:
+    seed = base_seed + worker_id + rank * 1000
+    np.random.seed(seed)
+    random.seed(seed)
+    torch.manual_seed(seed)
+
+
 def make_loaders(sources, device, rank, world_size, num_workers, prefetch_factor,
                  warp_path: Optional[str] = None, do_inpaint: bool = False, inpaint_frac: float = 0.0):
     weak_dev = WEAK_LABEL_DEVICE
@@ -1952,22 +1961,18 @@ def make_loaders(sources, device, rank, world_size, num_workers, prefetch_factor
     train_sampler = DistributedSampler(train_ds, num_replicas=world_size, rank=rank, shuffle=True, drop_last=False) if ddp_is_dist() else None
     val_sampler   = DistributedSampler(val_ds,   num_replicas=world_size, rank=rank, shuffle=False, drop_last=False) if ddp_is_dist() else None
 
-    def _wif(worker_id):
-        seed = SEED + worker_id + rank*1000
-        np.random.seed(seed)
-        random.seed(seed)
-        torch.manual_seed(seed)
-
     g = torch.Generator(); g.manual_seed(SEED + rank)
     pin = (device.type == "cuda")
+    worker_init = partial(_seed_worker, base_seed=SEED, rank=rank)
 
     def mk(ds, bs, shuffle, sampler):
         kwargs = dict(dataset=ds, batch_size=bs, shuffle=shuffle, sampler=sampler,
-                      num_workers=num_workers, pin_memory=pin, worker_init_fn=_wif,
+                      num_workers=num_workers, pin_memory=pin, worker_init_fn=worker_init,
                       generator=g, drop_last=False)
         if num_workers > 0:
             kwargs["persistent_workers"] = PERSISTENT_WORKERS
             kwargs["prefetch_factor"] = prefetch_factor
+            kwargs["multiprocessing_context"] = "spawn"
         return DataLoader(**kwargs)
 
     train_loader = mk(train_ds, BATCH_SIZE, shuffle=(train_sampler is None), sampler=train_sampler)
@@ -2689,6 +2694,7 @@ def parse_args():
     return p.parse_args()
 
 if __name__ == "__main__":
+    mp.set_start_method("spawn", force=True)
     args = parse_args()
     if getattr(args, "weak_cache_write_files", False):
         WEAK_CACHE_WRITE_FILES = True


### PR DESCRIPTION
## Summary
- add a module-level worker seeding helper that can be pickled by spawn workers
- update DataLoader construction to use the new helper while keeping spawn context configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d90758268c832a846798380a2cb18b