### PR TITLE
Define default fuse mode constant

### DIFF
--- a/ddp.py
+++ b/ddp.py
@@ -246,6 +246,7 @@ MIXED_PRECISION = True
 WEIGHT_DECAY = 1e-4
 LAMBDA_DBZ = 1.0
 DICE_WEIGHT = 0.5
+FUSE_MODE = "max"             # default fusion strategy for radar intensities
 LOG_EVERY = 100
 CKPT_PATH = os.path.join(WORK_DIR, "radar_cleaner_best.pt")
 


### PR DESCRIPTION
## Summary
- define the global FUSE_MODE default so downstream training code can reference it safely

## Testing
- python -m compileall ddp.py

------
https://chatgpt.com/codex/tasks/task_e_68d955fa957c832aa7b83c14a8987276